### PR TITLE
Add default case for switch statement

### DIFF
--- a/androidcallopencv/openCVLibrary249/src/main/java/org/opencv/android/CameraBridgeViewBase.java
+++ b/androidcallopencv/openCVLibrary249/src/main/java/org/opencv/android/CameraBridgeViewBase.java
@@ -326,6 +326,11 @@ public abstract class CameraBridgeViewBase extends SurfaceView implements Surfac
                 mListener.onCameraViewStopped();
             }
             break;
+        //missing default case
+        default:
+            // add default case
+            break;
+
         };
     }
 
@@ -337,6 +342,11 @@ public abstract class CameraBridgeViewBase extends SurfaceView implements Surfac
         case STOPPED:
             onExitStoppedState();
             break;
+        //missing default case
+        default:
+            // add default case
+            break;
+
         };
     }
 


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html