### PR TITLE
Add default case for switch statements

### DIFF
--- a/androidcallopencv/openCVTutorial2MixedProcessing/src/main/java/org/opencv/samples/tutorial2/Tutorial2Activity.java
+++ b/androidcallopencv/openCVTutorial2MixedProcessing/src/main/java/org/opencv/samples/tutorial2/Tutorial2Activity.java
@@ -148,6 +148,11 @@ public class Tutorial2Activity extends Activity implements CvCameraViewListener2
             mGray = inputFrame.gray();
             FindFeatures(mGray.getNativeObjAddr(), mRgba.getNativeObjAddr());
             break;
+        //missing default case
+        default:
+            // add default case
+            break;
+
         }
 
         return mRgba;


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html