### PR TITLE
Add default case for switch statements

### DIFF
--- a/androidcallopencv/openCVLibrary249/src/main/java/org/opencv/android/BaseLoaderCallback.java
+++ b/androidcallopencv/openCVLibrary249/src/main/java/org/opencv/android/BaseLoaderCallback.java
@@ -128,6 +128,12 @@ public abstract class BaseLoaderCallback implements LoaderCallbackInterface {
 
                 WaitMessage.show();
             } break;
+            //missing default case
+            default:
+                // add default case
+                break;
+
+
         }
     }
 


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html